### PR TITLE
Unix: Dump backtrace info in case of signals

### DIFF
--- a/include/pcl/UnixSignalException.h
+++ b/include/pcl/UnixSignalException.h
@@ -95,14 +95,18 @@ public:
     * Constructs a new %UnixSignalException object with the specified \a signal
     * number.
     */
-   UnixSignalException( int signal ) : pcl::Exception(), m_signal( signal )
+   UnixSignalException( int signal ) : pcl::Exception(), m_signal( signal ), m_details("")
+   {
+   }
+
+   UnixSignalException(int signal, const String& details) : pcl::Exception(), m_signal(signal), m_details(details)
    {
    }
 
    /*!
     * Copy constructor.
     */
-   UnixSignalException( const UnixSignalException& x ) : pcl::Exception( x ), m_signal( x.m_signal )
+   UnixSignalException( const UnixSignalException& x ) : pcl::Exception( x ), m_signal( x.m_signal ), m_details(x.m_details)
    {
    }
 
@@ -125,12 +129,27 @@ public:
    }
 
    /*!
+    * Returns ...
+    */
+   virtual String Details() const
+   {
+	   return m_details;
+   }
+
+   /*!
+    * Set ...
+    */
+   virtual void SetDetails(const String& details){
+	   m_details = details;
+   }
+
+   /*!
     * Returns a formatted error message with information on this signal
     * exception.
     */
    virtual String FormatInfo() const
    {
-      return String().Format( "Critical signal caught (%d): ", SignalNumber() ) + Message();
+      return String().Format( "Critical signal caught (%d): ", SignalNumber() ) + Message() + m_details;
    }
 
    /*!
@@ -155,7 +174,8 @@ public:
 
 protected:
 
-   int m_signal; // signal number
+   int    m_signal; // signal number
+   String m_details;
 };
 
 // ----------------------------------------------------------------------------
@@ -165,6 +185,9 @@ protected:
    {                                                                          \
    public:                                                                    \
       className() : pcl::UnixSignalException( sigNum )                        \
+      {                                                                       \
+      }                                                                       \
+      className(const String& details) : pcl::UnixSignalException( sigNum,details )\
       {                                                                       \
       }                                                                       \
       className( const className& x ) : pcl::UnixSignalException( x )         \

--- a/src/pcl/linux/g++/makefile-x64
+++ b/src/pcl/linux/g++/makefile-x64
@@ -474,6 +474,6 @@ post-build:
 	cp $(OBJ_DIR)/libPCL-pxi.a $(PCLLIBDIR64)
 
 ./x64/Release/%.o: ../../%.cpp
-	g++ -c -pipe -m64 -fPIC -D_REENTRANT -D__PCL_LINUX -I"$(PCLINCDIR)" -mtune=generic -mssse3 -O3 -minline-all-stringops -ffunction-sections -fdata-sections -fomit-frame-pointer -ffast-math -ftree-vectorize --param vect-max-version-for-alias-checks=1000 --param vect-max-version-for-alignment-checks=1000 -fvisibility=hidden -fvisibility-inlines-hidden -fnon-call-exceptions -std=c++11 -Wall -Wno-parentheses -MMD -MP -MF"$(@:%.o=%.d)" -o"$@" "$<"
+	g++ -c -pipe -m64 -fPIC -D_REENTRANT -D__PCL_LINUX -I"$(PCLINCDIR)" -mtune=generic -mssse3 -O3 -rdynamic -minline-all-stringops -ffunction-sections -fdata-sections -fomit-frame-pointer -ffast-math -ftree-vectorize --param vect-max-version-for-alias-checks=1000 --param vect-max-version-for-alignment-checks=1000 -fvisibility=hidden -fvisibility-inlines-hidden -fnon-call-exceptions -std=c++11 -Wall -Wno-parentheses -MMD -MP -MF"$(@:%.o=%.d)" -o"$@" "$<"
 	@echo ' '
 


### PR DESCRIPTION
Hi Juan,
here a first version of a backtrace dump in the Unix Signal handler. The backtrace contains demangled function names and the function offset. With a debug version of a module it should be possible to find the exact code location using the "addr2line" tool.

All modules should be linked with an additional compiler flag -rdynamic. The adaptation of the makefiles or the makefile generator is not part of this change. 

Unfortunately I was not able to test the changes on macos.

Klaus