### PR TITLE
Print latest server log entry to conole

### DIFF
--- a/src/modules/processes/contrib/kkretzschmar/INDIClient/IINDIDeviceControllerInstance.h
+++ b/src/modules/processes/contrib/kkretzschmar/INDIClient/IINDIDeviceControllerInstance.h
@@ -81,7 +81,8 @@ public:
    virtual Array<INDIDeviceListItem>& getDeviceList() = 0;
    virtual Array<INDIPropertyListItem>& getPropertyList() = 0;
    virtual ExclPropertyList getExclusivePropertyList() = 0;
-   virtual IsoString getCurrentMessage() const = 0;
+   virtual String CurrentServerMessage() const = 0;
+   virtual void SetCurrentServerMessage(const String& )  = 0;
 
    virtual String DownloadedImagePath() const = 0;
    virtual void SetDownloadedImagePath( const String& ) = 0;

--- a/src/modules/processes/contrib/kkretzschmar/INDIClient/INDI/indiapi.h
+++ b/src/modules/processes/contrib/kkretzschmar/INDIClient/INDI/indiapi.h
@@ -125,13 +125,13 @@ typedef enum
 /* The XML strings for these attributes may be any length but implementations
  * are only obligued to support these lengths for the various string attributes.
  */
-#define	MAXINDINAME	32
-#define	MAXINDILABEL	32
-#define	MAXINDIDEVICE	32
-#define	MAXINDIGROUP	32
-#define	MAXINDIFORMAT	32
-#define	MAXINDIBLOBFMT	32
-#define	MAXINDITSTAMP	32
+#define	MAXINDINAME	64
+#define	MAXINDILABEL	64
+#define	MAXINDIDEVICE	64
+#define	MAXINDIGROUP	64
+#define	MAXINDIFORMAT	64
+#define	MAXINDIBLOBFMT	64
+#define	MAXINDITSTAMP	64
 
 /*******************************************************************************
  * Typedefs for each INDI Property type.

--- a/src/modules/processes/contrib/kkretzschmar/INDIClient/INDICCDFrameInstance.cpp
+++ b/src/modules/processes/contrib/kkretzschmar/INDIClient/INDICCDFrameInstance.cpp
@@ -354,6 +354,12 @@ bool INDICCDFrameInstance::ExecuteGlobal()
             pcl::Sleep( 100 );
          }
 
+         // print latest INDI server log entry
+         console.WriteLn(String().Format("<end><cbr><br>===== Latest INDI server log entry:"));
+         console.WriteLn(String().Format("%s",IsoString(instance.CurrentServerMessage()).c_str()));
+
+         console.WriteLn();
+
          if ( serverSendsImage )
          {
             for ( T.Reset(); !instance.HasDownloadedImage(); )

--- a/src/modules/processes/contrib/kkretzschmar/INDIClient/INDIClient.cpp
+++ b/src/modules/processes/contrib/kkretzschmar/INDIClient/INDIClient.cpp
@@ -167,9 +167,9 @@ void INDIClient::newMessage( INDI::BaseDevice* dp, int messageID )
    const char* message = dp->messageQueue( messageID );
    if ( message != nullptr )
    {
-      m_instance->getCurrentMessage() = IsoString( message );
+      m_instance->SetCurrentServerMessage(String(message));
       if ( m_scriptInstance )
-         m_scriptInstance->getCurrentMessage() = IsoString( message );
+         m_scriptInstance->SetCurrentServerMessage(String(message));
    }
 }
 

--- a/src/modules/processes/contrib/kkretzschmar/INDIClient/INDIDeviceControllerInstance.h
+++ b/src/modules/processes/contrib/kkretzschmar/INDIClient/INDIDeviceControllerInstance.h
@@ -95,9 +95,14 @@ public:
       return o_devices;
    }
 
-   virtual IsoString getCurrentMessage() const
+   virtual String CurrentServerMessage() const
    {
-      return m_currentMessage;
+	   return m_currentMessage;
+   }
+
+   virtual void SetCurrentServerMessage(const String& message)
+   {
+      m_currentMessage = message;
    }
 
    ExclPropertyList getExclusivePropertyList()
@@ -163,7 +168,7 @@ private:
    PropertyListType    o_properties;
    String              o_getCommandResult;
 
-   IsoString           m_currentMessage;
+   String              m_currentMessage;
    bool                m_internalAbortFlag;
    String              m_downloadedImagePath;
    pcl::Mutex          m_mutex; // for access to propertyList

--- a/src/modules/processes/contrib/kkretzschmar/INDIClientTest/fakes/FakeINDIClient.cpp
+++ b/src/modules/processes/contrib/kkretzschmar/INDIClientTest/fakes/FakeINDIClient.cpp
@@ -9,8 +9,12 @@
 #include "FakeINDIClient.h"
 //#include "../indiapi.h"
 #include "INDIPropertyBuilder.h"
-#include "error.h"
+#include "pcl/Exception.h"
 
+#define CHECK_POINTER(PTR) \
+		if (PTR==NULL) {\
+		  throw FatalError(String().Format("Error in %s line %d: Null pointer exception",__FILE__,__LINE__));\
+		}
 
 namespace pcl {
 

--- a/src/modules/processes/contrib/kkretzschmar/INDIClientTest/fakes/FakeINDIInstance.h
+++ b/src/modules/processes/contrib/kkretzschmar/INDIClientTest/fakes/FakeINDIInstance.h
@@ -21,7 +21,12 @@ public:
 	virtual ExclPropertyList getExclusivePropertyList() {return m_exclusivePropertyList;};
 	virtual Array<INDIPropertyListItem>& getPropertyList() {return m_propertyList;}
 	virtual Array<INDIDeviceListItem>& getDeviceList(){return m_deviceList; }
-	virtual IsoString& getCurrentMessage() {return m_currentMessage;}
+	virtual String CurrentServerMessage() const {return m_currentMessage;}
+	virtual void SetCurrentServerMessage(const String& message) {m_currentMessage = message;}
+
+	virtual String DownloadedImagePath() const {return m_downloadedImagePath;}
+	virtual void SetDownloadedImagePath( const String& path) {m_downloadedImagePath=path;}
+
 	virtual void setImageDownloadedFlag(bool flag){}
 	virtual bool getImageDownloadedFlag(){return true;}
 
@@ -29,7 +34,8 @@ private:
 	Array<INDIDeviceListItem>    m_deviceList;
 	Array<INDIPropertyListItem>  m_propertyList;
 	ExclPropertyList             m_exclusivePropertyList;
-	IsoString                    m_currentMessage;
+	String                       m_currentMessage;
+	String                       m_downloadedImagePath;
 };
 
 } /* namespace pcl */


### PR DESCRIPTION
Hi Juan,
during my testing I found a problem which has its origin in a bug in the current INDI CCD driver implementation. The current INDI CCD driver accepts setting server side download directories which do not exists. This leads to an endless loop (in the Spinstatus) when using the upload mode "UploadServerAndClient". Of course, it is possible to abort the process but you don't get the info what happend, also because the INDIClient process GUI is set to disabled mode. 

I fixed this by writing the latest INDI server log entry to the console, so that the user get noticed that something went wrong. I'll also ask the INDI forum whether they could provide a directory exists on server side.   

I'd prefer if we could re-enable the interactive mode with the INDICCDFrame and INDIDeviceController default GUI before releasing our first version - especially the INDIDeviceController is a kind of Monitor which provides a lot of status information. It should not be blocked during process runtime (if not used via javascript exectuteGlobal())

I have a very simple javascript demo, which works fine. I'd like to use simple javascript unittests for testing with a local INDI server and simulator devices. Do you already have an javascript asserts module? 

I also have difficulties to find the  value of the Gobal setting "ImageWindow/DownloadsDirectory" I cannot find it in the Global Preferences process. Do I have to recompile _all_ modules, to get the new global settings?

Happy Easter
Klaus
