### PR TITLE
Latest fixes on windows

### DIFF
--- a/src/modules/processes/contrib/kkretzschmar/INDIClient/INDI/BaseClientImpl.cpp
+++ b/src/modules/processes/contrib/kkretzschmar/INDIClient/INDI/BaseClientImpl.cpp
@@ -217,11 +217,6 @@ bool INDI::BaseClientImpl::disconnectServer()
         return true;
 
     sConnected = false;
-#if defined(WIN32)
-#define SHUT_RDWR SD_BOTH
-#endif
-
-    
 
 #if !defined(WIN32)
 	shutdown(sockfd, SHUT_RDWR);

--- a/src/modules/processes/contrib/kkretzschmar/INDIClient/INDI/BaseClientImpl.cpp
+++ b/src/modules/processes/contrib/kkretzschmar/INDIClient/INDI/BaseClientImpl.cpp
@@ -221,9 +221,10 @@ bool INDI::BaseClientImpl::disconnectServer()
 #define SHUT_RDWR SD_BOTH
 #endif
 
-    shutdown(sockfd, SHUT_RDWR);
+    
 
 #if !defined(WIN32)
+	shutdown(sockfd, SHUT_RDWR);
     if (svrwfp != NULL)
         fclose(svrwfp);
    svrwfp = NULL;


### PR DESCRIPTION
Hi Juan,
I found some time to test on windows. I used a windows 10 machine as a client communicating to a linux laptop with a running INDI server remotely. Everything works fine!  The only issue I found is that the first connect to the remote INDI server took quite a while long. Maybe due to inefficient  DNS cache lookup . The DeviceController GUI then did not update properly. But the second connect and further connects then went well.

Workaround: Connect a second time, or use IP addresses instead of host names.

Then while taking some pictures of Mercury transit I took some images with my DSLR and the gphoto driver. Everything worked fine except the server upload modes. The short exposure times were not accepted,  the camera behaved as if it would be in bulb mode. I assume a bug on the gphoto driver side here. I'll investigate ...

Last thing to do is to update the documentation, there are outdated pictures from the old interfaces, I can do that. 

But I think we are now ready for release! The modules are in a great shape now, thanks for all your effort (quite big, sorry for that ;) ). Interactive and scripting modes are working very well, I wasn't able to bring the prototype that far. I am looking forward for the developments to come (I am already working on the INDI mount module).  

Thanks!
Klaus
