### PR TITLE
Remove [PCL]/devTools section it does not exist anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,6 @@ Here is a list of subdirectories, along with descriptions of the files therein. 
    The complete source code of PixInsight Class Library (PCL). Along with the PCL headers distributed on the [PCL]/include/pcl directory, you can use these source files with the provided makefiles and project files to rebuild PCL on your system.
 </dd></dl>
 
-**[PCL]/devTools**
-
-<dl><dd>
-   Some small helpers for development on Linux. See the README.md in this directory
-</dd></dl>
-
 
 ## Supported Compilers
 


### PR DESCRIPTION
The sub-directory devTools/* was removed with
commit a7bccfef570fa98f68aefafac516590d92d44aec so remove
the section in the README.md documentation about this topic.